### PR TITLE
Refactor the crate so its fully async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shutdown"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sander van Harmelen <sander@vanharmelen.nl>"]
-edition = "2018"
+edition = "2021"
 description = "shutdown can be used to gracefully exit (part of) a running program"
 documentation = "https://docs.rs/shutdown/"
 homepage = "https://github.com/svanharmelen/shutdown"
@@ -13,11 +13,14 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = "0.3"
 log = "0.4"
-signal-hook = "0.2"
-tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+signal-hook = "0.3"
+signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio-util = "0.7"
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"
 libc = "0.2"
 tokio = { version = "1", features = ["macros", "time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,50 +1,40 @@
 //! # shutdown
 //!
 //! This crate is meant to be used together with Tokio as it provides an
-//! async solution for listening for shutdown signals.
+//! async solution for listening and forwarding shutdown signals.
 //!
-//! When creating a new "root" shutdown channel, it will register itself to
+//! When creating a new "root" shutdown signal, it will register itself to
 //! listen for SIGINT and SIGTERM signals. When a SIGNINT or SIGTERM is received,
 //! it will unregister itself again so any additional signals will be processed
 //! as usual (interrupting or terminating the process in most cases). Besides a
 //! SIGINT or SIGTERM signal, you can also trigger a shutdown signal manually by
-//! calling [shutdown_now](Shutdown::shutdown_now).
+//! calling [signal](Shutdown::signal).
 //!
 //! You can form a tree of branches and subscribers and choose to only shutdown
 //! a specific branch. This will shutdown all subscribers but also any child
 //! branches and their subscribers. This can be helpful in async applications
 //! where lots of tasks spawn lots of tasks, that spawn lots of tasks...
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
+use std::sync::{atomic::AtomicBool, Arc};
 
+use futures::stream::StreamExt;
 use log::debug;
-use signal_hook::{cleanup, iterator::Signals, SIGINT, SIGTERM};
-use tokio::sync::broadcast;
+use signal_hook::{
+    consts::{SIGINT, SIGTERM},
+    flag,
+};
+use signal_hook_tokio::Signals;
+use tokio_util::sync::CancellationToken;
 
-type Sender = Arc<Mutex<Option<broadcast::Sender<()>>>>;
-type Receiver = broadcast::Receiver<()>;
-
-#[derive(Debug)]
 pub struct Shutdown {
-    shutdown: Arc<AtomicBool>,
-    signal: Sender,
-    notify: Receiver,
-}
-
-impl Clone for Shutdown {
-    fn clone(&self) -> Self {
-        self.subscribe()
-    }
+    token: CancellationToken,
 }
 
 impl Shutdown {
-    /// Create a new shutdown channel. In most cases the channel will be
-    /// shutdown when CTRL-C is pressed and the process receives a SIGINT or
-    /// SIGTERM signal. If needed you can also call [shutdown_now](Shutdown::shutdown_now)
-    /// manually to send a shutdown signal programmatically.
+    /// Create a new shutdown signal. In most cases the signal will be
+    /// triggered when CTRL-C is pressed and the process receives a SIGINT or
+    /// SIGTERM signal. If needed you can also call [signal](Shutdown::signal)
+    /// to send a shutdown signal programmatically.
     ///
     /// # Examples
     ///
@@ -54,42 +44,38 @@ impl Shutdown {
     /// let root = Shutdown::new().unwrap();
     /// ```
     pub fn new() -> Result<Self, std::io::Error> {
-        let (sender, receiver) = broadcast::channel(1);
-        let parent = Arc::new(Mutex::new(Some(sender)));
+        // Create a cancellation token.
+        let token = CancellationToken::new();
 
-        // Create the shutdown struct first, as it needs to clone
-        // the parent (sender) part of the broadcast channel before
-        // moving itself into the signal monitoring thread.
+        // Create a new shutdown signal.
         let shutdown = Self {
-            shutdown: Arc::new(AtomicBool::new(false)),
-            signal: parent.clone(),
-            notify: receiver,
+            token: token.clone(),
         };
 
-        // Register the SIGINT and SIGTERM signals and their respective
-        // cleanup handlers. This makes sure the signals are reset back
-        // to their default behavior after receiving the first signal.
-        let signals = Signals::new(&[SIGINT, SIGTERM])?;
-        cleanup::register(SIGINT, vec![SIGTERM, SIGINT])?;
-        cleanup::register(SIGTERM, vec![SIGTERM, SIGINT])?;
+        // Register the SIGINT and SIGTERM signals.
+        let mut signals = Signals::new([SIGINT, SIGTERM])?;
 
-        // Spawn a dedicated OS thread for listening for signals.
-        std::thread::spawn(move || {
-            if let Some(signal) = signals.forever().next() {
+        // Spawn a Tokio task that will listen for signals.
+        tokio::spawn(async move {
+            if let Some(signal) = signals.next().await {
                 debug!("Received a shutdown signal: {}", signal);
-                if let Some(sender) = parent.lock().unwrap().take() {
-                    drop(sender);
-                }
+                // Register conditional shutdown handlers. This makes sure the
+                // application will terminate after receiving a second signal.
+                flag::register_conditional_shutdown(SIGINT, 0, Arc::new(AtomicBool::new(true)))
+                    .unwrap();
+                flag::register_conditional_shutdown(SIGTERM, 0, Arc::new(AtomicBool::new(true)))
+                    .unwrap();
+                // Send the shutdown signal by cancelling the token.
+                token.cancel();
             }
         });
 
         Ok(shutdown)
     }
 
-    /// Create a new branch (child) that can be shutdown independent of the
-    /// root (parent) channel. When the root (or parent to be more precise)
-    /// is shutdown, the new branch (and any child branches) will also be
-    /// shutdown.
+    /// Create a new branch (child) that can be signalled independent of the
+    /// root (parent). When the root (or parent to be more precise) is signalled,
+    /// the new branch (and any child branches) will also be signalled.
     ///
     /// # Examples
     ///
@@ -99,42 +85,13 @@ impl Shutdown {
     /// let root = Shutdown::new().unwrap();
     /// let branch = root.branch();
     ///
-    /// // Shutdown a specific branch
-    /// branch.shutdown_now();
+    /// // Signal a specific branch
+    /// branch.signal();
     /// ```
     pub fn branch(&self) -> Self {
-        let (sender, receiver) = broadcast::channel(1);
-        let child = Arc::new(Mutex::new(Some(sender)));
-
-        // Create a branch that allows shutting down this, and
-        // all tasks subscribed or branched from this task.
-        let branch = Self {
-            shutdown: Arc::new(AtomicBool::new(false)),
-            signal: child.clone(),
-            notify: receiver,
-        };
-
-        match self.signal.lock().unwrap().as_ref() {
-            // If our parent is not dropped yet, spawn a task that
-            // listens for a shutdown signal and, when received,
-            // forwards the signal by dropping the child (signal).
-            Some(parent) => {
-                let mut notify = parent.subscribe();
-                tokio::spawn(async move {
-                    let _ = notify.recv().await;
-                    if let Some(child) = child.lock().unwrap().take() {
-                        drop(child);
-                    }
-                });
-            }
-            // If the parent is already dropped, immediately drop
-            // the child (signal) to forward the shutdown signal.
-            None => {
-                drop(child.lock().unwrap().take());
-            }
+        Self {
+            token: self.token.child_token(),
         }
-
-        branch
     }
 
     /// Create a new subscriber (sibling) that listens to an existing root (or
@@ -149,30 +106,12 @@ impl Shutdown {
     /// let subscriber = root.subscribe();
     /// ```
     pub fn subscribe(&self) -> Self {
-        match self.signal.lock().unwrap().as_ref() {
-            Some(sender) => {
-                // Return a new shutdown struct that allows creating
-                // additional sub-subscribers or branches from it.
-                Self {
-                    shutdown: self.shutdown.clone(),
-                    signal: self.signal.clone(),
-                    notify: sender.subscribe(),
-                }
-            }
-            None => {
-                // Return a new shutdown struct with a dummy receiver
-                // as a shutdown signal was already received.
-                let (_, receiver) = broadcast::channel(1);
-                Self {
-                    shutdown: self.shutdown.clone(),
-                    signal: self.signal.clone(),
-                    notify: receiver,
-                }
-            }
+        Self {
+            token: self.token.clone(),
         }
     }
 
-    /// Returns `true` is the channel received a shutdown signal.
+    /// Returns `true` if a shutdown signal has been received.
     ///
     /// # Examples
     ///
@@ -181,16 +120,16 @@ impl Shutdown {
     ///
     /// let root = Shutdown::new().unwrap();
     ///
-    /// while !root.is_shutdown() {
+    /// while !root.is_signalled() {
     ///     // Do stuff...
     /// }
     /// ```
-    pub fn is_shutdown(&self) -> bool {
-        self.shutdown.load(Ordering::SeqCst)
+    pub fn is_signalled(&self) -> bool {
+        self.token.is_cancelled()
     }
 
-    /// Manually shutdown the root or a branch. This causes all connected
-    /// subscribers and any child branches to be shutdown as well.
+    /// Manually signal the root or a branch. This causes all connected
+    /// subscribers and any child branches to be signalled as well.
     ///
     /// # Examples
     ///
@@ -200,16 +139,11 @@ impl Shutdown {
     /// let root = Shutdown::new().unwrap();
     /// let branch = root.branch();
     ///
-    /// // Trigger a manual shutdown from code
-    /// root.shutdown_now();
+    /// // Trigger a signal from code
+    /// root.signal();
     /// ```
-    pub fn shutdown_now(&self) {
-        if let Some(sender) = self.signal.lock().unwrap().take() {
-            // Register that a shutdown request was received.
-            self.shutdown.store(true, Ordering::SeqCst);
-            // Drop the sender to forward the shutdown signal.
-            drop(sender);
-        }
+    pub fn signal(&self) {
+        self.token.cancel();
     }
 
     /// Block until a shutdown signal is received. This can, for example, be
@@ -227,23 +161,13 @@ impl Shutdown {
     ///     let mut root = Shutdown::new().unwrap();
     ///
     ///     tokio::select! {
-    ///         _ = root.recv() => (),
+    ///         _ = root.signalled() => (),
     ///         _ = sleep(Duration::from_secs(300)) => (), // Long runnnig task
     ///     }
     /// }
     /// ```
-    pub async fn recv(&mut self) {
-        // Return early if a shutdown request has already been received.
-        if self.shutdown.load(Ordering::SeqCst) {
-            return;
-        }
-
-        // Wait until a shutdown signal is received. The possible
-        // "lag error" can be ignored as only one value is ever send.
-        let _ = self.notify.recv().await;
-
-        // Register that a shutdown request was received.
-        self.shutdown.store(true, Ordering::SeqCst);
+    pub async fn signalled(&self) {
+        self.token.cancelled().await;
     }
 }
 
@@ -261,22 +185,22 @@ mod tests {
             .is_test(true)
             .try_init();
 
-        let mut root = Shutdown::new().unwrap();
+        let root = Shutdown::new().unwrap();
         let branch1 = root.branch();
         let branch2 = branch1.branch();
         let sub1 = branch1.subscribe();
         let sub2 = branch2.subscribe();
 
         tokio::select! {
-            _ = root.recv() => (),
+            _ = root.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
 
-        assert!(!root.is_shutdown(), "root shutdown without notify");
-        assert!(!branch1.is_shutdown(), "branch1 shutdown without notify");
-        assert!(!branch2.is_shutdown(), "branch2 shutdown without notify");
-        assert!(!sub1.is_shutdown(), "subscriber1 shutdown without notify");
-        assert!(!sub2.is_shutdown(), "subscriber2 shutdown without notify");
+        assert!(!root.is_signalled(), "root shutdown without notify");
+        assert!(!branch1.is_signalled(), "branch1 shutdown without notify");
+        assert!(!branch2.is_signalled(), "branch2 shutdown without notify");
+        assert!(!sub1.is_signalled(), "subscriber1 shutdown without notify");
+        assert!(!sub2.is_signalled(), "subscriber2 shutdown without notify");
     }
 
     #[tokio::test]
@@ -287,92 +211,92 @@ mod tests {
             .is_test(true)
             .try_init();
 
-        let mut root = Shutdown::new().unwrap();
+        let root = Shutdown::new().unwrap();
         let branch1 = root.branch();
         let branch2 = branch1.branch();
-        let mut sub1 = branch1.subscribe();
-        let mut sub2 = branch2.subscribe();
+        let sub1 = branch1.subscribe();
+        let sub2 = branch2.subscribe();
 
-        unsafe { libc::raise(signal_hook::SIGINT) };
+        unsafe { libc::raise(signal_hook::consts::SIGINT) };
 
         tokio::select! {
-            _ = root.recv() => (),
+            _ = root.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub1.recv() => (),
+            _ = sub1.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub2.recv() => (),
+            _ = sub2.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
 
-        assert!(root.is_shutdown(), "root not shutdown (signal)");
-        assert!(branch1.is_shutdown(), "branch1 not shutdown (signal)");
-        assert!(branch2.is_shutdown(), "branch2 not shutdown (signal)");
-        assert!(sub1.is_shutdown(), "subscriber1 not shutdown (signal)");
-        assert!(sub2.is_shutdown(), "subscriber2 not shutdown (signal)");
+        assert!(root.is_signalled(), "root not shutdown (signal)");
+        assert!(branch1.is_signalled(), "branch1 not shutdown (signal)");
+        assert!(branch2.is_signalled(), "branch2 not shutdown (signal)");
+        assert!(sub1.is_signalled(), "subscriber1 not shutdown (signal)");
+        assert!(sub2.is_signalled(), "subscriber2 not shutdown (signal)");
     }
 
     #[tokio::test]
     async fn shutdown_now() {
-        let mut root = Shutdown::new().unwrap();
+        let root = Shutdown::new().unwrap();
         let branch1 = root.branch();
         let branch2 = branch1.branch();
-        let mut sub1 = branch1.subscribe();
-        let mut sub2 = branch2.subscribe();
+        let sub1 = branch1.subscribe();
+        let sub2 = branch2.subscribe();
 
-        root.shutdown_now();
+        root.signal();
 
         tokio::select! {
-            _ = root.recv() => (),
+            _ = root.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub1.recv() => (),
+            _ = sub1.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub2.recv() => (),
+            _ = sub2.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
 
-        assert!(root.is_shutdown(), "root not shutdown (now)");
-        assert!(branch1.is_shutdown(), "branch1 not shutdown (now)");
-        assert!(branch2.is_shutdown(), "branch2 not shutdown (now)");
-        assert!(sub1.is_shutdown(), "subscriber1 not shutdown (now)");
-        assert!(sub2.is_shutdown(), "subscriber2 not shutdown (now)");
+        assert!(root.is_signalled(), "root not shutdown (manual)");
+        assert!(branch1.is_signalled(), "branch1 not shutdown (manual)");
+        assert!(branch2.is_signalled(), "branch2 not shutdown (manual)");
+        assert!(sub1.is_signalled(), "subscriber1 not shutdown (manual)");
+        assert!(sub2.is_signalled(), "subscriber2 not shutdown (manual)");
     }
 
     #[tokio::test]
     async fn shutdown_branch() {
-        let mut root = Shutdown::new().unwrap();
+        let root = Shutdown::new().unwrap();
         let branch1 = root.branch();
         let branch2 = branch1.branch();
-        let mut sub1 = branch1.subscribe();
-        let mut sub2 = branch2.subscribe();
+        let sub1 = branch1.subscribe();
+        let sub2 = branch2.subscribe();
 
-        sub2.shutdown_now();
+        sub2.signal();
 
         tokio::select! {
-            _ = root.recv() => (),
+            _ = root.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub1.recv() => (),
+            _ = sub1.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
         tokio::select! {
-            _ = sub2.recv() => (),
+            _ = sub2.signalled() => (),
             _ = sleep(Duration::from_secs(1)) => (),
         }
 
-        assert!(!root.is_shutdown(), "root shutdown without notify");
-        assert!(!branch1.is_shutdown(), "branch1 shutdown without notify");
-        assert!(!sub1.is_shutdown(), "subscriber1 shutdown without notify");
+        assert!(!root.is_signalled(), "root shutdown without notify");
+        assert!(!branch1.is_signalled(), "branch1 shutdown without notify");
+        assert!(!sub1.is_signalled(), "subscriber1 shutdown without notify");
 
-        assert!(branch2.is_shutdown(), "branch2 not shutdown (now)");
-        assert!(sub2.is_shutdown(), "subscriber2 not shutdown (now)");
+        assert!(branch2.is_signalled(), "branch2 not shutdown (manual)");
+        assert!(sub2.is_signalled(), "subscriber2 not shutdown (manual)");
     }
 }


### PR DESCRIPTION
The current version no longer creates a dedicated OS thread and also doesn’t have to be mutable to listen for incomming signals anymore.

The internals are now mostly a wrapper around the `CancellationToken` (that can be found in the `tokio-util` crate), but with the addition that it's being triggered (cancelled) by OS signals.

This version also renamed some of the methods, so version v0.3.0 will have breaking changes!